### PR TITLE
Add time zone parameter to query API calls

### DIFF
--- a/lib/plausible/stats/time.ex
+++ b/lib/plausible/stats/time.ex
@@ -32,17 +32,19 @@ defmodule Plausible.Stats.Time do
     {first_datetime, last_datetime}
   end
 
-  def utc_boundaries(%Query{date_range: date_range}, site) do
+  def utc_boundaries(%Query{date_range: date_range, timezone: timezone}, site) do
     {:ok, first} = NaiveDateTime.new(date_range.first, ~T[00:00:00])
+
+    tz = if(timezone, do: timezone, else: site.timezone)
 
     first_datetime =
       first
-      |> Timezones.to_utc_datetime(site.timezone)
+      |> Timezones.to_utc_datetime(tz)
       |> beginning_of_time(site.native_stats_start_at)
 
     {:ok, last} = NaiveDateTime.new(date_range.last |> Timex.shift(days: 1), ~T[00:00:00])
 
-    last_datetime = Timezones.to_utc_datetime(last, site.timezone)
+    last_datetime = Timezones.to_utc_datetime(last, tz)
 
     {first_datetime, last_datetime}
   end


### PR DESCRIPTION
### Changes
Added `timezone` parameter to query API calls (timeseries, aggregate, breakdown).  Results will be returned in the given time zone if specified, defaulting to the site's configured time zone if not specified.

### Not done, but would need to be if we want to contribute this to the upstream
- Validate time zone parameter
- Tests with different time zones
- Verify a few other places where `site.timezone` is used... do they need to updated?

